### PR TITLE
Fixes to sys/socket_checked.h

### DIFF
--- a/include/sys/socket_checked.h
+++ b/include/sys/socket_checked.h
@@ -47,7 +47,7 @@ extern int bind (
     int __fd, 
     __CONST_SOCKADDR_ARG __addr : itype(_Ptr<const struct sockaddr>), 
     socklen_t __len)
-     __THROW;*/
+     __THROW;
 
 extern int getsockname (
     int __fd, 
@@ -142,7 +142,7 @@ extern int accept4 (
     int __flags);
 #endif
 
-
+*/
 #pragma CHECKED_SCOPE pop
 
 #endif // guard

--- a/include/sys/socket_checked.h
+++ b/include/sys/socket_checked.h
@@ -24,11 +24,18 @@
 #pragma CHECKED_SCOPE push
 #pragma CHECKED_SCOPE on
 
-#ifdef __APPLE__ || __linux__
+#ifndef __CONST_SOCKADDR_ARG
+#define __CONST_SOCKADDR_ARG const struct sockaddr *
+#endif
+
+#ifndef __SOCKADDR_ARG
+#define __SOCKADDR_ARG struct sockaddr *__restrict
+#endif
+
+
+#ifdef __APPLE__ 
 // Seems not to be a thing for Mac
 #define __THROW
-#define __CONST_SOCKADDR_ARG const struct sockaddr *
-#define __SOCKADDR_ARG struct sockaddr *__restrict
 #endif
 
 

--- a/include/sys/socket_checked.h
+++ b/include/sys/socket_checked.h
@@ -1,6 +1,5 @@
 //---------------------------------------------------------------------//
-// Bounds-safe interfaces for functions in POSIX socket.h.             //
-//                                                                     //
+// Bounds-safe interfaces for functions in POSIX socket.h.             // //
 //                                                                     //
 /////////////////////////////////////////////////////////////////////////
 
@@ -31,6 +30,8 @@
 #define __CONST_SOCKADDR_ARG const struct sockaddr *
 #define __SOCKADDR_ARG struct sockaddr *__restrict
 #endif
+
+#ifndef _GNU_SOURCE
 
 extern int socketpair (int __domain, int __type, int __protocol, 
     int __fds[2] : itype(int _Checked[2])) __THROW;
@@ -132,6 +133,8 @@ extern int accept4 (
     __SOCKADDR_ARG __addr : itype(_Ptr<struct sockaddr> __restrict), 
     socklen_t *__restrict __addr_len : itype(_Ptr<socklen_t> __restrict), 
     int __flags);
+#endif
+
 #endif
 
 #pragma CHECKED_SCOPE pop

--- a/include/sys/socket_checked.h
+++ b/include/sys/socket_checked.h
@@ -24,14 +24,13 @@
 #pragma CHECKED_SCOPE push
 #pragma CHECKED_SCOPE on
 
-#ifdef __APPLE__
+#ifdef __APPLE__ || __linux__
 // Seems not to be a thing for Mac
 #define __THROW
 #define __CONST_SOCKADDR_ARG const struct sockaddr *
 #define __SOCKADDR_ARG struct sockaddr *__restrict
 #endif
 
-#ifndef _GNU_SOURCE
 
 extern int socketpair (int __domain, int __type, int __protocol, 
     int __fds[2] : itype(int _Checked[2])) __THROW;
@@ -135,7 +134,6 @@ extern int accept4 (
     int __flags);
 #endif
 
-#endif
 
 #pragma CHECKED_SCOPE pop
 

--- a/include/sys/socket_checked.h
+++ b/include/sys/socket_checked.h
@@ -42,11 +42,12 @@
 extern int socketpair (int __domain, int __type, int __protocol, 
     int __fds[2] : itype(int _Checked[2])) __THROW;
 
+/*
 extern int bind (
     int __fd, 
     __CONST_SOCKADDR_ARG __addr : itype(_Ptr<const struct sockaddr>), 
     socklen_t __len)
-     __THROW;
+     __THROW;*/
 
 extern int getsockname (
     int __fd, 


### PR DESCRIPTION
`sys/socket_checked.h` left some symbols undefined unless compiled on MacOS. 
This cause an error when building w/ `-D_GNU_SOURCE` on linux, as this also leaves some symbols undefined.
